### PR TITLE
fix: wrong potentialAction ViewAction

### DIFF
--- a/src/MicrosoftTeamsNotification.groovy
+++ b/src/MicrosoftTeamsNotification.groovy
@@ -21,7 +21,7 @@ rundeckPlugin(NotificationPlugin){
             potentialAction: [
                 [
                     "@context": "http://schema.org",
-                    "@type": "ViewAction",
+                    "@type": "ActionCard",
                     name: "Seed job execution",
                     target: ["${execution.href}"]
                 ]
@@ -44,7 +44,7 @@ rundeckPlugin(NotificationPlugin){
             potentialAction: [
                 [
                     "@context": "http://schema.org",
-                    "@type": "ViewAction",
+                    "@type": "ActionCard",
                     name: "Seed job execution",
                     target: ["${execution.href}"]
                 ]
@@ -67,7 +67,7 @@ rundeckPlugin(NotificationPlugin){
             potentialAction: [
                 [
                     "@context": "http://schema.org",
-                    "@type": "ViewAction",
+                    "@type": "ActionCard",
                     name: "Seed job execution",
                     target: ["${execution.href}"]
                 ]


### PR DESCRIPTION
update potentialAction type to ActionCard as Teams it's not supported anymore and will get you a HTTP 400 error
``` 
HTTP/2 400
Bad payload received by generic incoming
```